### PR TITLE
Set compress and remove bytesize

### DIFF
--- a/lib/sprockets/standalone.rb
+++ b/lib/sprockets/standalone.rb
@@ -129,7 +129,6 @@ module Sprockets
         files[path] = {
           'logical_path' => asset.logical_path,
           'mtime'        => asset.mtime.iso8601,
-          'size'         => asset.bytesize,
           'digest'       => asset.digest
         }
         assets[asset.logical_path] = path


### PR DESCRIPTION
Compress was not set as an attr_accessor, and asset.bytesize was undefined.
