### PR TITLE
Reference 'length' instead of 'bytesize' on asset

### DIFF
--- a/lib/sprockets/standalone.rb
+++ b/lib/sprockets/standalone.rb
@@ -129,7 +129,7 @@ module Sprockets
         files[path] = {
           'logical_path' => asset.logical_path,
           'mtime'        => asset.mtime.iso8601,
-          'size'         => asset.bytesize,
+          'size'         => asset.length,
           'digest'       => asset.digest
         }
         assets[asset.logical_path] = path


### PR DESCRIPTION
Truly support `"sprockets", "~> 2.0"` dependency as the `#bytesize` method alias to `#length` [seems to have been added](https://github.com/sstephenson/sprockets/commit/4f611d21cc526feda894916e7342d2cafc2f3122) in Sprockets 2.3.1.