### PR TITLE
Jrc/update to work with sprockets 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Sprockets::Standalone::RakeTask.new(:assets) do |task, sprockets|
   task.assets   = %w(app.js app.css *.png *.svg *.woff)
   task.sources  = %w(app/assets vendor/assets)
   task.output   = File.expand_path('../assets', __FILE__)
-  task.compress = false
-  task.digest   = false
+  task.manifest_name  = 'manifest.json'
 
   sprockets.js_compressor  = :uglifier
   sprockets.css_compressor = :sass
@@ -45,15 +44,14 @@ If you pass a block you can configure additional parameters:
 
 3)	`task.output` - Define output directory. Default is `dist`.
 
-4)	`task.compress` - Set to true if you want pre-compressed assets. Default is false.
+4)	`task.manifest_name` - Set the name to be used for the `manifest.json`
 
-5)	`task.digest` - Set to true if you want to include a file digest in the file name of generated assets. Default is false.
-
-6)	`task.environment` - Set custom sprockets environment.
+5)	`task.environment` - Set custom sprockets environment.
 
 You can also customize the sprockets environment in the block to configure additional preprocessors or compressors.
 
 Note: Sprockets-standalone will always use a manifest.json even when asset digests are turned off. The manifest.json will be used to track changes. If you manually change the generated assets that will not be override when compiling assets unless there is also a change if the matching source files.
+
 You will need to remove generated assets (`rake assets:clobber`) to force regeneration of all assets.
 
 ## Contributing

--- a/lib/sprockets/standalone/version.rb
+++ b/lib/sprockets/standalone/version.rb
@@ -1,5 +1,5 @@
 module Sprockets
   module Standalone
-    VERSION = "1.2.1"
+    VERSION = "3.0.0"
   end
 end

--- a/sprockets-standalone.gemspec
+++ b/sprockets-standalone.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rake"
-  spec.add_dependency "sprockets", "~> 2.0"
+  spec.add_dependency "sprockets", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.4"
 end


### PR DESCRIPTION
I was looking to incorporate your existing gem and I noticed a lot of the functionality is out of date. Especially with how Sprockets now compiles assets through the Manifest object, it seemed reasonable to just hook right into sprockets there instead of having your custom overloaded methods.

Also, allow the ability for the user to specify the name of the manifest file that is created.

Let me know.